### PR TITLE
Add light theme background for dashboard pages

### DIFF
--- a/kavindra-ui/src/app/components/pages/_authenticated/_dashboard/org-dashboard-create-project-page/org-dashboard-create-project-page.component.html
+++ b/kavindra-ui/src/app/components/pages/_authenticated/_dashboard/org-dashboard-create-project-page/org-dashboard-create-project-page.component.html
@@ -1,4 +1,4 @@
-<div class="py-8 px-8 border-8 border-black rounded-3xl min-h-screen dark:bg-dark-primary"
+<div class="py-8 px-8 border-8 border-black rounded-3xl min-h-screen bg-light-primary dark:bg-dark-primary"
      style="box-shadow: 5px 5px 0 black; outline: 3px solid black;">
   <form>
     <div class="space-y-12 animate-fadeinup">

--- a/kavindra-ui/src/app/components/pages/_authenticated/_dashboard/project-dashboard-page/project-dashboard-page.component.html
+++ b/kavindra-ui/src/app/components/pages/_authenticated/_dashboard/project-dashboard-page/project-dashboard-page.component.html
@@ -1,4 +1,4 @@
-<div class="py-8 px-8 border-8 border-black rounded-3xl min-h-screen dark:bg-dark-primary"
+<div class="py-8 px-8 border-8 border-black rounded-3xl min-h-screen bg-light-primary dark:bg-dark-primary"
      style="box-shadow: 5px 5px 0 black; outline: 3px solid black;">
   <div class="space-y-12 animate-fadeinup px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3">


### PR DESCRIPTION
Updated the `bg-light-primary` class for both the project dashboard and create project pages to ensure proper background styling in light mode. This enhances visual consistency across themes.