### PR TITLE
Set placeholder text color in textarea to gray

### DIFF
--- a/kavindra-api/widget/views/message.css
+++ b/kavindra-api/widget/views/message.css
@@ -1,3 +1,7 @@
+textarea::placeholder {
+  color: gray !important;
+}
+
 .js-widget-overlay {
     z-index: 10001;
     position: fixed;


### PR DESCRIPTION
---

**Description:**

Updated the CSS to change the placeholder text color in textareas to gray for improved consistency and user experience.