### PR TITLE
Update monthly price for Startup plan

### DIFF
--- a/kavindra-api/src/app/payments/services/payments/payments.service.ts
+++ b/kavindra-api/src/app/payments/services/payments/payments.service.ts
@@ -29,7 +29,7 @@ export class PaymentsService implements OnModuleInit {
       id: '3e1a5257-58a8-4769-970a-2214ef7bf80e',
       name: 'Startup',
       description: 'A plan that scales with your rapidly growing business.',
-      monthlyPrice: '$29.99',
+      monthlyPrice: '$24.99',
       features: [
         'Up to 15 projects',
         'Up to 150 team members',


### PR DESCRIPTION
The monthly price of the Startup plan has been lowered from $29.99 to $24.99 to stay competitive and align with business strategies.