### PR TITLE
Add Plausible Analytics script to head for Nuxt app

### DIFF
--- a/nuxt-ui/nuxt.config.ts
+++ b/nuxt-ui/nuxt.config.ts
@@ -21,7 +21,10 @@ export default defineNuxtConfig({
     },
     app: {
       head: {
-        script: [{ src: "https://www.api.kavindra.io/v1/scripts/feedback-widget.js" }],
+        script: [
+          { src: 'https://www.api.kavindra.io/v1/scripts/feedback-widget.js' },
+          { src: 'https://plausible.io/js/script.file-downloads.outbound-links.pageview-props.revenue.tagged-events.js', async: true, 'data-domain': 'kavindra.io'}
+        ],
       },
       pageTransition: { name: "page", mode: "out-in" },
     },


### PR DESCRIPTION
<details>
<summary>Details</summary>

Integrate Plausible Analytics by adding its script to the head configuration in the Nuxt app. The script loads asynchronously and tracks file downloads and outbound links.

</details>